### PR TITLE
Add Appcache for offline support in mobile safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="manifest" href="/manifest.json">
+
+    <link rel="stylesheet" href="stylesheets/default.css"/>
+
     <meta name="description" content="Caltrain times whenever you want them.">
 
     <meta property="og:type" content="website"/>
@@ -20,18 +23,16 @@
     <meta name="twitter:description" content="Caltrain times whenever you want them.">
     <meta name="twitter:image" content="https://caltrainschedule.io/icons/android-chrome-192x192.png">
 
-    <!-- what do these two do again? -->
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes"> <!-- ios standalone -->
+    <meta name="mobile-web-app-capable" content="yes"> <!-- legacy chrome a2hs -->
 
-    <link rel="apple-touch-icon" href="icons/icon.png" />
-    <link rel="apple-touch-icon" sizes="114x114" href="icons/icon-57@2x.png" />
-    <link rel="apple-touch-icon" sizes="72x72" href="icons/icon-72.png" />
-    <link rel="apple-touch-icon" sizes="144x144" href="icons/icon-72@2x.png" />
-    <link rel="apple-touch-icon" sizes="76x76" href="icons/icon-76.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="icons/icon-76@2x.png" />
+    <link rel="apple-touch-icon" href="icons/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="icons/apple-touch-icon-114x114.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="icons/apple-touch-icon-72x72.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="icons/apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="icons/apple-touch-icon-76x76.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="icons/apple-touch-icon-152x152.png" />
 
-    <link rel="stylesheet" href="stylesheets/default.css"/>
 </head>
 <body>
     <header>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
-<head>
+<head manifest="ios.appcache">
     <title>Caltrain Schedule</title>
     <meta charset="utf-8">
 

--- a/ios.appcache
+++ b/ios.appcache
@@ -1,0 +1,21 @@
+CACHE MANIFEST
+
+#version 1.0 2-28-2017
+
+CACHE:
+
+# internal HTML documents
+https://caltrainschedule.io/
+
+# style sheets
+https://caltrainschedule.io/stylesheets/default.css
+
+# style sheet images
+"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAQAAAD/5HvMAAAAqklEQVR4Ae3WRwKCQBBE0To5eYYjm22XZjI9hv9rZ3wqqPrKiMhuBggQIECAAAECBAjQ14EA5To+7Bb0eF0uhyrZwFVyqvLnzCdVcq7s5JRKUJmKU6joJvlyys4nKZ44hQdnOKnwPJeqTpIDp5Y9rO4kuXO6SStzGtmbNUpQkHUsJOWkJ0XZgEU51coGrpVDubYPuyU8XpfzfxkQIECAAAECBAgQIEDOEdEFZ84Z0079TZ0AAAAASUVORK5CYII="
+
+# javascript files
+https://www.google-analytics.com/analytics.js
+https://caltrainschedule.io/javascripts/default.js
+
+NETWORK:
+*


### PR DESCRIPTION
super easy.

it's deployed at https://developertoolswg.github.io/caltrainschedule.io/ if you wanna test.

(this PR depends on the last)

fixes #8