### PR TITLE
Don't use holiday dates for weekday/saturday/sunday schedule

### DIFF
--- a/javascripts/default.js
+++ b/javascripts/default.js
@@ -182,8 +182,20 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = (function(name, fn
       target_date.setDate(target_date.getDate() + diff);
     }
 
-    var date_str = formatDate(target_date);
+    var service_ids = getValidServiceIdsForDate(calendar, target_date, target_schedule);
 
+    // remove and add service_ids based on the calendar_dates.txt exceptions
+    const {added, removed} = getCalendarExceptions(calendar_dates, target_date);
+    service_ids = service_ids.filter(service_id => !removed.includes(service_id)).concat(added);
+
+    if (service_ids.length === 0) {
+      console.log("Can't get service for now.");
+    }
+    return service_ids;
+  }
+
+  function getValidServiceIdsForDate(calendar, target_date, target_schedule) {
+    var date_str = formatDate(target_date);
     // calendar:
     //   service_id => [monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date]
     // calendar_dates:
@@ -193,28 +205,32 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = (function(name, fn
       var item = calendar[service_id];
       return (item.start_date <= date_str) && (date_str <= item.end_date);
     }).filter(function(service_id) {
-      // check calendar available days
+      // verify ther are available calendar available days
       return calendar[service_id][target_schedule];
     });
-
-    // consider exceptional days like holidays defined in calendar_dates file
-    service_ids = service_ids.filter(function(service_id) {
-      // check calendar_dates with exception_type 2 (if any to remove)
-      return !(service_id in calendar_dates) ||
-        calendar_dates[service_id].filter(function(exception_date) {
-          return (exception_date[0] === date_str) && (exception_date[1] === 2);
-        }).length === 0;
-    }).concat(Object.keys(calendar_dates).filter(function(service_id) {
-      // check calendar_dates with exception_type 1 (if any to add)
-      return calendar_dates[service_id].filter(function(exception_date) {
-        return (exception_date[0] === date_str) && (exception_date[1] === 1);
-      }).length !== 0;
-    }));
-
-    if (service_ids.length === 0) {
-      console.log("Can't get service for now.");
-    }
     return service_ids;
+  }
+
+  function getCalendarExceptions(calendar_dates, target_date) {
+    const Service = {
+      Added: 1,
+      Removed: 2,
+    };
+    const getMatchingDate = (date_str, calendar_date) => calendar_date.find(([exp_date]) => exp_date == date_str) || [];
+    const exp_service_ids = Object.keys(calendar_dates);
+    const date_str = formatDate(target_date);
+
+    const removed = exp_service_ids.filter((service_id) => {
+      const [exception_date, exception_type] = getMatchingDate(date_str, calendar_dates[service_id]);
+      if (exception_type === Service.Removed) return true;
+    });
+
+    const added = exp_service_ids.filter(function(service_id) {
+      const [exception_date, exception_type] = getMatchingDate(date_str, calendar_dates[service_id]);
+      if (exception_type === Service.Added) return true;
+    });
+
+    return {removed, added};
   }
 
   function get_available_services(routes, calendar, calendar_dates) {

--- a/javascripts/default.js
+++ b/javascripts/default.js
@@ -179,6 +179,7 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = (function(name, fn
       // when it's not, keep the schedule and increment the date until the next that matches schedule and isn't a weird exception case.
       let found = false;
       for (var i = 0; found === false; i++) {
+        // TBH this technique is probably still not perfect, alas.
         const daysToShift = (DAY_OF_WEEK_MAP[target_schedule] + 7 - today_day_of_week) % 7;
         const daysToIncrement = (target_schedule === 'saturday' || target_schedule === 'sunday') ? 7 : 1;
         target_date.setDate(target_date.getDate() + daysToShift + (i * daysToIncrement));
@@ -214,7 +215,7 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = (function(name, fn
       var item = calendar[service_id];
       return (item.start_date <= date_str) && (date_str <= item.end_date);
     }).filter(function(service_id) {
-      // verify ther are available calendar available days
+      // verify there are available calendar available days
       return calendar[service_id][target_schedule];
     });
     return service_ids;

--- a/javascripts/default.js
+++ b/javascripts/default.js
@@ -160,6 +160,9 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = (function(name, fn
 
 
   function get_service_ids(calendar, calendar_dates) {
+    console.assert(Object.keys(calendar).length === Object.keys(calendar_dates).length);
+    console.assert(Object.keys(calendar).every(key => Object.keys(calendar_dates).includes(key)));
+
     var target_date = new Date();
     var today_day_of_week = new Date().getDay(); // getDay is "0 for Sunday"
 

--- a/javascripts/default.js
+++ b/javascripts/default.js
@@ -166,8 +166,7 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = (function(name, fn
     var target_date = new Date();
     var today_day_of_week = new Date().getDay(); // getDay is "0 for Sunday"
 
-    var selected_schedule = get_selected_schedule();
-    var target_schedule = selected_schedule;
+    var target_schedule = get_selected_schedule();
     if (target_schedule === 'now') {
       // when it's now, keep today's date and migrate target_schedule to real one
       switch (today_day_of_week) {
@@ -177,9 +176,18 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = (function(name, fn
         default: console.error('Unknown current day', today_day_of_week); return [];
       }
     } else {
-      // when it's not, keep the schedule and migrate date to the next date matching the schedule
-      var diff = (DAY_OF_WEEK_MAP[target_schedule] + 7 - today_day_of_week) % 7;
-      target_date.setDate(target_date.getDate() + diff);
+      // when it's not, keep the schedule and attempt the next that matches schedule and isn't a weird exception case.
+      let found = false;
+      for (var i = 0; found === false; i++) {
+        var diff = (DAY_OF_WEEK_MAP[target_schedule] + 7 - today_day_of_week) % 7;
+        target_date.setDate(target_date.getDate() + diff + i);
+
+        const service_ids = getValidServiceIdsForDate(calendar, target_date, target_schedule);
+        if (service_ids.length === 0) continue;
+
+        const {added} = getCalendarExceptions(calendar_dates, target_date);
+        found = added.length === 0;
+      }
     }
 
     var service_ids = getValidServiceIdsForDate(calendar, target_date, target_schedule);

--- a/javascripts/default.js
+++ b/javascripts/default.js
@@ -176,11 +176,12 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = (function(name, fn
         default: console.error('Unknown current day', today_day_of_week); return [];
       }
     } else {
-      // when it's not, keep the schedule and attempt the next that matches schedule and isn't a weird exception case.
+      // when it's not, keep the schedule and increment the date until the next that matches schedule and isn't a weird exception case.
       let found = false;
       for (var i = 0; found === false; i++) {
-        var diff = (DAY_OF_WEEK_MAP[target_schedule] + 7 - today_day_of_week) % 7;
-        target_date.setDate(target_date.getDate() + diff + i);
+        const daysToShift = (DAY_OF_WEEK_MAP[target_schedule] + 7 - today_day_of_week) % 7;
+        const daysToIncrement = (target_schedule === 'saturday' || target_schedule === 'sunday') ? 7 : 1;
+        target_date.setDate(target_date.getDate() + daysToShift + (i * daysToIncrement));
 
         const service_ids = getValidServiceIdsForDate(calendar, target_date, target_schedule);
         if (service_ids.length === 0) continue;


### PR DESCRIPTION
on jan 1st, the user could ask for a weekday schedule.
we would see that jan 1st (a monday) is a weekday, and use that schedule. However it's a holiday, so that's not the typical weekday schedule. 
now we increment until we find a good day.

fixes #50